### PR TITLE
Fix use of __version__

### DIFF
--- a/src/xtgeoapp_grd3dmaps/__init__.py
+++ b/src/xtgeoapp_grd3dmaps/__init__.py
@@ -1,3 +1,10 @@
 # -*- coding: utf-8 -*-
 
 """Top-level package for xtgeoapp_grd3dmaps"""
+
+try:
+    from ._theversion import version
+
+    __version__ = version
+except ImportError:
+    __version__ = "0.0.0"


### PR DESCRIPTION
Version is written to `_theversion.py`, but `__version__` is never set. This causes an error when building the documentation. 

Resolved using the same approach as in `fmu-config`.