### PR TITLE
Add numpy as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-xtgeo >= 2.0.0
+numpy
 PyYAML
+xtgeo >= 2.0.0


### PR DESCRIPTION
This repository uses `numpy` explicitly and should hence add it as a requirement although it also comes via the `xtgeo` requirement...