### PR TITLE
Adopt to xtgeoviz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyYAML
 ert
 numpy
 xtgeo
+xtgeoviz

--- a/scripts/setup_functions.py
+++ b/scripts/setup_functions.py
@@ -1,0 +1,90 @@
+"""Setup helpers for setup.py in xtgeoviz package."""
+import os
+from os.path import exists
+from shutil import rmtree
+import fnmatch
+
+from distutils.command.clean import clean as _clean
+
+
+def parse_requirements(filename):
+    """Load requirements from a pip requirements file."""
+    try:
+        lineiter = (line.strip() for line in open(filename))
+        return [line for line in lineiter if line and not line.startswith("#")]
+    except OSError:
+        return []
+
+
+# ======================================================================================
+# Overriding and extending setup commands; here "clean"
+# ======================================================================================
+
+
+class CleanUp(_clean):
+    """Custom implementation of ``clean`` command.
+
+    Overriding clean in order to get rid if "dist" folder and etc, see setup.py.
+    """
+
+    CLEANFOLDERS = (
+        "__pycache__",
+        "pip-wheel-metadata",
+        ".eggs",
+        "dist",
+        "build",
+        "sdist",
+        "wheel",
+        ".pytest_cache",
+        "docs/apiref",
+        "docs/_build",
+        "result_images",
+        "TMP",
+    )
+
+    CLEANFOLDERSRECURSIVE = ["__pycache__", "_tmp_*", "*.egg-info"]
+    CLEANFILESRECURSIVE = ["*.pyc", "*.pyo"]
+
+    @staticmethod
+    def ffind(pattern, path):
+        """Find files."""
+        result = []
+        for root, _, files in os.walk(path):
+            for name in files:
+                if fnmatch.fnmatch(name, pattern):
+                    result.append(os.path.join(root, name))
+        return result
+
+    @staticmethod
+    def dfind(pattern, path):
+        """Find folders."""
+        result = []
+        for root, dirs, _ in os.walk(path):
+            for name in dirs:
+                if fnmatch.fnmatch(name, pattern):
+                    result.append(os.path.join(root, name))
+        return result
+
+    def run(self):
+        """Execute run.
+
+        After calling the super class implementation, this function removes
+        the directories specific to scikit-build ++.
+        """
+        super(CleanUp, self).run()
+
+        for dir_ in CleanUp.CLEANFOLDERS:
+            if exists(dir_):
+                print("Removing: {}".format(dir_))
+            if not self.dry_run and exists(dir_):
+                rmtree(dir_)
+
+        for dir_ in CleanUp.CLEANFOLDERSRECURSIVE:
+            for pdir in self.dfind(dir_, "."):
+                print("Remove folder {}".format(pdir))
+                rmtree(pdir)
+
+        for fil_ in CleanUp.CLEANFILESRECURSIVE:
+            for pfil in self.ffind(fil_, "."):
+                print("Remove file {}".format(pfil))
+                os.unlink(pfil)

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,9 @@ from os.path import basename
 from os.path import splitext
 
 from setuptools import setup, find_packages
+from scripts import setup_functions
+
+CMDCLASS = {"clean": setup_functions.CleanUp}
 
 APPS = ("grid3d_hc_thickness", "grid3d_average_map")
 
@@ -78,6 +81,7 @@ setup(
             "xtgeoapp_grd3dmaps_jobs = xtgeoapp_grd3dmaps.hook_implementations.jobs"
         ],
     },
+    cmdclass=CMDCLASS,
     include_package_data=True,
     install_requires=requirements,
     zip_safe=False,

--- a/src/xtgeoapp_grd3dmaps/avghc/_compute_avg.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_compute_avg.py
@@ -7,7 +7,6 @@ import numpy.ma as ma
 import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.surface import RegularSurface
-from xtgeo.xyz import Polygons
 
 xtg = XTGeoDialog()
 logger = xtg.functionlogger(__name__)
@@ -127,11 +126,11 @@ def do_avg_plotting(config, avgd):
         if pcfg["faultpolygons"] is not None:
             xtg.say("Try: {}".format(pcfg["faultpolygons"]))
             try:
-                fau = Polygons(pcfg["faultpolygons"], fformat="guess")
+                fau = xtgeo.polygons_from_file(pcfg["faultpolygons"], fformat="guess")
                 faults = {"faults": fau}
                 xtg.say("Use fault polygons")
-            except Exception as e:
-                xtg.say(e)
+            except OSError as err:
+                xtg.say(err)
                 faults = None
                 xtg.say("No fault polygons")
 

--- a/src/xtgeoapp_grd3dmaps/avghc/_compute_avg.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_compute_avg.py
@@ -8,6 +8,8 @@ import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.surface import RegularSurface
 
+from xtgeoviz import quickplot
+
 xtg = XTGeoDialog()
 logger = xtg.functionlogger(__name__)
 
@@ -134,14 +136,15 @@ def do_avg_plotting(config, avgd):
                 faults = None
                 xtg.say("No fault polygons")
 
-        xmap.quickplot(
+        quickplot(
+            xmap,
             filename=plotfile,
             title=pcfg["title"],
             subtitle=pcfg["subtitle"],
             infotext=pcfg["infotext"],
             xlabelrotation=pcfg["xlabelrotation"],
             minmax=usevrange,
-            colortable=pcfg["colortable"],
+            colormap=pcfg["colortable"],
             faults=faults,
         )
 
@@ -260,7 +263,7 @@ def _avg_plotsettings(config, zname, pname):
     if "_filterinfo" in config and config["_filterinfo"]:
         subtitle = config["_filterinfo"]
 
-    # assing settings to a dictionary which is returned
+    # passing settings to a dictionary which is returned
     plotcfg = {}
     plotcfg["title"] = title
     plotcfg["subtitle"] = subtitle

--- a/src/xtgeoapp_grd3dmaps/avghc/_compute_hcpfz.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_compute_hcpfz.py
@@ -1,4 +1,3 @@
-import pprint
 import numpy.ma as ma
 
 from xtgeo.common import XTGeoDialog
@@ -38,10 +37,6 @@ def get_hcpfz(config, initd, restartd, dates, hcmode, filterarray):
 
     else:
         hcpfzd = _get_hcpfz_ecl(config, initd, restartd, dates, hcmode, filterarray)
-
-    alldates = hcpfzd.keys()
-
-    ppalldates = pprint.PrettyPrinter(indent=4)
 
     return hcpfzd
 
@@ -129,8 +124,6 @@ def _get_hcpfz_ecl(config, initd, restartd, dates, hcmode, filterarray):
                 )
 
     alldates = hcpfzd.keys()
-
-    ppalldates = pprint.PrettyPrinter(indent=4)
 
     purecdates = [str(cda) for cda in cdates if "--" not in str(cda)]
     pureadates = [str(adate) for adate in alldates if "--" not in str(adate)]

--- a/src/xtgeoapp_grd3dmaps/avghc/_compute_hcpfz.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_compute_hcpfz.py
@@ -42,7 +42,6 @@ def get_hcpfz(config, initd, restartd, dates, hcmode, filterarray):
     alldates = hcpfzd.keys()
 
     ppalldates = pprint.PrettyPrinter(indent=4)
-    logger.debug("After cleaning: {}".format(ppalldates.pformat(alldates)))
 
     return hcpfzd
 
@@ -61,7 +60,7 @@ def _get_hcpfz_ecl(config, initd, restartd, dates, hcmode, filterarray):
 
     for date in dates:
 
-        if hcmode == "oil" or hcmode == "gas":
+        if hcmode in ("oil", "gas"):
             usehc = restartd["s" + hcmode + "_" + str(date)]
         elif hcmode == "comb":
             usehc1 = restartd["s" + "oil" + "_" + str(date)]
@@ -102,11 +101,8 @@ def _get_hcpfz_ecl(config, initd, restartd, dates, hcmode, filterarray):
                 ' method"'.format(hcmethod)
             )
 
-        logger.info("HCPFZ minimum is {}".format(hcpfzd[date].min()))
-        logger.info("HCPFZ maximum is {}".format(hcpfzd[date].max()))
-
     for key, val in hcpfzd.items():
-        logger.info("hcpfzd.items: {}   {}".format(key, type(val)))
+        logger.info("hcpfzd.items: %s   %s", key, type(val))
 
     # An important issue here is that one may ask for difference dates,
     # not just dates. Hence need to iterate over the dates in the input
@@ -135,7 +131,6 @@ def _get_hcpfz_ecl(config, initd, restartd, dates, hcmode, filterarray):
     alldates = hcpfzd.keys()
 
     ppalldates = pprint.PrettyPrinter(indent=4)
-    logger.debug("All dates: {}".format(ppalldates.pformat(alldates)))
 
     purecdates = [str(cda) for cda in cdates if "--" not in str(cda)]
     pureadates = [str(adate) for adate in alldates if "--" not in str(adate)]

--- a/src/xtgeoapp_grd3dmaps/avghc/_configparser.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_configparser.py
@@ -129,7 +129,7 @@ def yconfig(inputfile, tmp=False, standard=False):
                 config = yaml.load(stream, Loader=YamlXLoader)
             except ConstructorError as errmsg:
                 xtg.error(errmsg)
-                raise SystemExit
+                raise SystemExit from errmsg
 
     xtg.say("Input config YAML file <{}> is read...".format(inputfile))
 
@@ -332,9 +332,6 @@ def yconfig_override(config, args, appname):
         if args.dates:
             newconfig["input"]["dates"] = args.dates
 
-    pp = pprint.PrettyPrinter(indent=4)
-    out = pp.pformat(newconfig)
-
     return newconfig
 
 
@@ -473,5 +470,7 @@ def yconfig_addons(config, appname):
             newconfig["zonation"]["zranges"] = zconfig["zranges"]
         if "superranges" in zconfig:
             newconfig["zonation"]["superranges"] = zconfig["superranges"]
+
+    xtg.say(f"Add configuration to {appname}")
 
     return newconfig

--- a/src/xtgeoapp_grd3dmaps/avghc/_configparser.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_configparser.py
@@ -1,10 +1,10 @@
 import argparse
 import sys
 import os.path
-import yaml
 import pprint
 import copy
 import datetime
+import yaml
 
 from xtgeo.common import XTGeoDialog
 from xtgeoapp_grd3dmaps.avghc._loader import YamlXLoader, ConstructorError
@@ -18,8 +18,6 @@ def parse_args(args, appname, appdescr):
 
     if args is None:
         args = sys.argv[1:]
-    else:
-        args = args
 
     usetxt = appname + " --config some.yaml ... "
 
@@ -106,7 +104,7 @@ def parse_args(args, appname, appdescr):
 
     logger.debug("Command line args: ")
     for arg in vars(args):
-        logger.debug("{}  {}".format(arg, getattr(args, arg)))
+        logger.debug("%s  %s", arg, getattr(args, arg))
 
     return args
 
@@ -120,7 +118,7 @@ def yconfig(inputfile, tmp=False, standard=False):
     """Read from YAML file, returns a dictionary."""
 
     if not os.path.isfile(inputfile):
-        logger.critical("STOP! No such config file exists: {}".format(inputfile))
+        logger.critical("STOP! No such config file exists: %s", inputfile)
         raise SystemExit
 
     with open(inputfile, "r") as stream:
@@ -140,7 +138,7 @@ def yconfig(inputfile, tmp=False, standard=False):
     out = pp.pformat(config)
     logger.info("\n%s", out)
 
-    logger.info("CONFIG:\n {}".format(config))
+    logger.info("CONFIG:\n %s", config)
 
     # if the file is a temporary file, delete:
     if tmp:
@@ -333,15 +331,9 @@ def yconfig_override(config, args, appname):
 
         if args.dates:
             newconfig["input"]["dates"] = args.dates
-            logger.debug(
-                "YAML config overruled by cmd line: dates are now {}".format(
-                    newconfig["eclinput"]["dates"]
-                )
-            )
 
     pp = pprint.PrettyPrinter(indent=4)
     out = pp.pformat(newconfig)
-    logger.debug("After override: \n{}".format(out))
 
     return newconfig
 
@@ -415,7 +407,7 @@ def yconfig_set_defaults(config, appname):
     if appname == "grid3d_hc_thickness":
 
         if "dates" not in newconfig["input"]:
-            if newconfig["computesettings"]["mode"] in ("rock"):
+            if newconfig["computesettings"]["mode"] in "rock":
                 xtg.say('No date give, probably OK since "rock" mode)')
             else:
                 xtg.warn('Warning: No date given, set date to "unknowndate")')
@@ -463,7 +455,7 @@ def yconfig_set_defaults(config, appname):
 
     pp = pprint.PrettyPrinter(indent=4)
     out = pp.pformat(newconfig)
-    logger.debug("After setting defaults: \n{}".format(out))
+    logger.debug("After setting defaults: \n%s", out)
 
     return newconfig
 

--- a/src/xtgeoapp_grd3dmaps/avghc/_get_grid_props.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_get_grid_props.py
@@ -250,9 +250,9 @@ def import_data(config, appname, gfile, initlist, restartlist, dates):
                 restobjects.append(prop)
         except KeywordFoundNoDateError as rwarn:
             logger.info("Keyword found but not for this date %s", rwarn)
-            raise SystemExit("STOP")
+            raise SystemExit("STOP") from rwarn
         except Exception as message:
-            raise SystemExit(message)
+            raise SystemExit(message) from message
         else:
             logger.info("Works further...")
             for prop in tmp.props:
@@ -524,7 +524,7 @@ def get_numpies_hc_thickness(config, grd, initobjects, restobjects, dates):
     return initd, restartd
 
 
-def get_numpies_avgprops(config, grd, initobjects, restobjects, dates):
+def get_numpies_avgprops(config, grd, initobjects, restobjects):
     """Process for average map; to get the needed numpies"""
 
     actnum = grd.get_actnum().get_npvalues3d(fill_value=0)

--- a/src/xtgeoapp_grd3dmaps/avghc/_get_grid_props.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_get_grid_props.py
@@ -322,7 +322,7 @@ def import_filters(config, appname, grd):
                 drangetxt = list(drange.values())
                 drange = list(drange.keys())
             elif isinstance(drange, list):
-                drangetxt = [val for val in drange]
+                drangetxt = list(drange)
 
             irange = flist.get("intvrange", None)
             discrete = flist.get("discrete", False)

--- a/src/xtgeoapp_grd3dmaps/avghc/_hc_plotmap.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_hc_plotmap.py
@@ -2,9 +2,11 @@
 
 import getpass
 from time import localtime, strftime
-import numpy as np
 from collections import OrderedDict
 
+import numpy as np
+
+import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.surface import RegularSurface
 from xtgeo.xyz import Polygons
@@ -20,7 +22,7 @@ def do_hc_mapping(config, initd, hcpfzd, zonation, zoned, hcmode):
     mapzd = OrderedDict()
 
     if "templatefile" in config["mapsettings"]:
-        basemap = RegularSurface(config["mapsettings"]["templatefile"])
+        basemap = xtgeo.surface_from_file(config["mapsettings"]["templatefile"])
         basemap.values = 0.0
     else:
         ncol = config["mapsettings"].get("ncol")
@@ -51,7 +53,6 @@ def do_hc_mapping(config, initd, hcpfzd, zonation, zoned, hcmode):
             usezonation[:, :, :] = 0
             logger.debug(usezonation)
             for zr in zrange:
-                logger.debug("ZR is {}".format(zr))
                 usezonation[zonation == zr] = 888
 
             usezrange = 888

--- a/src/xtgeoapp_grd3dmaps/avghc/_hc_plotmap.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_hc_plotmap.py
@@ -10,6 +10,8 @@ import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.surface import RegularSurface
 
+from xtgeoviz import quickplot
+
 xtg = XTGeoDialog()
 
 logger = xtg.functionlogger(__name__)
@@ -130,7 +132,8 @@ def do_hc_plotting(config, mapzd, hcmode, filtermean=None):
                     xtg.say(err)
                     faults = None
 
-            xmap.quickplot(
+            quickplot(
+                xmap,
                 filename=plotfile,
                 title=pcfg["title"],
                 subtitle=pcfg["subtitle"],

--- a/src/xtgeoapp_grd3dmaps/avghc/_loader.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_loader.py
@@ -3,17 +3,13 @@
 import os.path
 from collections import OrderedDict
 import io
-
-try:
-    file_types = (file, io.IOBase)
-except NameError:
-    file_types = (io.IOBase,)
-
 import yaml
 from yaml.constructor import ConstructorError
 from yaml.nodes import MappingNode
 
 from xtgeo.common import XTGeoDialog
+
+file_types = (io.IOBase,)
 
 xtg = XTGeoDialog()
 logger = xtg.functionlogger(__name__)
@@ -31,7 +27,7 @@ class YamlXLoader(yaml.Loader):
     def __init__(self, stream, ordered=False):
         self._ordered = ordered  # for OrderedDict
         self._root = os.path.split(stream.name)[0]
-        super(YamlXLoader, self).__init__(stream)
+        super().__init__(stream)
 
         YamlXLoader.add_constructor(
             yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
@@ -191,7 +187,7 @@ class YLoader(yaml.Loader):
     """
 
     def __init__(self, *args, **kwargs):
-        super(YLoader, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.add_constructor("!include", self._include)
         if "root" in kwargs:
             self.root = kwargs["root"]

--- a/src/xtgeoapp_grd3dmaps/avghc/_loader.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_loader.py
@@ -137,7 +137,7 @@ class YamlXLoader(yaml.Loader):
                     node.start_mark,
                     "found unacceptable key (%s)" % exc,
                     key_node.start_mark,
-                )
+                ) from exc
             # check for duplicate keys
             if key in mapping:
                 raise ConstructorError(

--- a/src/xtgeoapp_grd3dmaps/avghc/_mapsettings.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_mapsettings.py
@@ -19,7 +19,7 @@ def check_mapsettings(config, grd):
     cfmp = config["mapsettings"]
 
     if "templatefile" in cfmp:
-        mymap = xtgeo.surface.RegularSurface(cfmp["templatefile"])
+        mymap = xtgeo.surface_from_file(cfmp["templatefile"])
         xmin = mymap.xmin
         xmax = mymap.xmax
         ymin = mymap.ymin

--- a/src/xtgeoapp_grd3dmaps/avghc/grid3d_average_map.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/grid3d_average_map.py
@@ -16,7 +16,7 @@ from . import _compute_avg
 from . import _mapsettings
 
 try:
-    from ..theversion import version as __version__
+    from xtgeoapp_grd3dmaps._theversion import version as __version__
 except ImportError:
     __version__ = "0.0.0"
 
@@ -98,7 +98,7 @@ def import_pdata(config, gfile, initlist, restartlist, dates):
         config, APPNAME, gfile, initlist, restartlist, dates
     )
     specd, averaged = _get_grid_props.get_numpies_avgprops(
-        config, grd, initobjects, restobjects, dates
+        config, grd, initobjects, restobjects
     )
 
     # returns also dates since dates list may be updated after import

--- a/src/xtgeoapp_grd3dmaps/avghc/grid3d_hc_thickness.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/grid3d_hc_thickness.py
@@ -16,7 +16,7 @@ from . import _hc_plotmap
 from . import _mapsettings
 
 try:
-    from ..theversion import version as __version__
+    from xtgeoapp_grd3dmaps._theversion import version as __version__
 except ImportError:
     __version__ = "0.0.0"
 

--- a/src/xtgeoapp_grd3dmaps/contact/_compute_contact.py
+++ b/src/xtgeoapp_grd3dmaps/contact/_compute_contact.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+import xtgeo
 from xtgeo.common import XTGeoDialog
 from xtgeo.surface import RegularSurface
 
@@ -11,7 +12,7 @@ def gridmap_contact(config, specd, propd, dates):
     """Compute a contact as a gridded map surface"""
 
     if "templatefile" in config["mapsettings"]:
-        xmap = RegularSurface(config["mapsettings"]["templatefile"])
+        xmap = xtgeo.surface_from_file(config["mapsettings"]["templatefile"])
         xmap.values = 0.0
     else:
         ncol = config["mapsettings"].get("ncol")

--- a/tests/test_grid3d_average_map1.py
+++ b/tests/test_grid3d_average_map1.py
@@ -5,8 +5,8 @@ import shutil
 import glob
 from pathlib import Path
 
+import xtgeo
 from xtgeo.common import XTGeoDialog
-from xtgeo.surface import RegularSurface as RS
 
 import xtgeoapp_grd3dmaps.avghc.grid3d_average_map as xx
 from .test_grid3d_hc_thickness2 import assert_almostequal
@@ -38,7 +38,7 @@ def test_average_map1b():
     os.chdir(str(Path(__file__).absolute().parent.parent))
     xx.main(["--config", "tests/yaml/avg1b.yml"])
 
-    z1poro = RS(os.path.join(td, "z1--avg1b_average_por.gri"))
+    z1poro = xtgeo.surface_from_file(os.path.join(td, "z1--avg1b_average_por.gri"))
     assert_almostequal(z1poro.values.mean(), 0.1598, 0.001, "Mean value")
     assert_almostequal(z1poro.values.std(), 0.04, 0.003, "Std. dev")
 
@@ -52,7 +52,7 @@ def test_average_map1c():
     os.chdir(str(Path(__file__).absolute().parent.parent))
     xx.main(["--config", "tests/yaml/avg1c.yml"])
 
-    z1poro = RS(os.path.join(td, "all--avg1c_average_por.gri"))
+    z1poro = xtgeo.surface_from_file(os.path.join(td, "all--avg1c_average_por.gri"))
     assert_almostequal(z1poro.values.mean(), 0.1678, 0.001, "Mean value")
 
 

--- a/tests/test_grid3d_average_map1.py
+++ b/tests/test_grid3d_average_map1.py
@@ -1,15 +1,15 @@
 import os
 import sys
-import pytest
 import shutil
 import glob
 from pathlib import Path
+
+import pytest
 
 import xtgeo
 from xtgeo.common import XTGeoDialog
 
 import xtgeoapp_grd3dmaps.avghc.grid3d_average_map as xx
-from .test_grid3d_hc_thickness2 import assert_almostequal
 
 xtg = XTGeoDialog()
 logger = xtg.basiclogger(__name__)
@@ -17,7 +17,7 @@ logger = xtg.basiclogger(__name__)
 if not xtg.testsetup():
     sys.exit(-9)
 
-td = xtg.tmpdir
+TMPD = xtg.tmpdir
 testpath = xtg.testpath
 
 skiplargetest = pytest.mark.skipif(xtg.bigtest is False, reason="Big tests skip")
@@ -38,11 +38,11 @@ def test_average_map1b():
     os.chdir(str(Path(__file__).absolute().parent.parent))
     xx.main(["--config", "tests/yaml/avg1b.yml"])
 
-    z1poro = xtgeo.surface_from_file(os.path.join(td, "z1--avg1b_average_por.gri"))
-    assert_almostequal(z1poro.values.mean(), 0.1598, 0.001, "Mean value")
-    assert_almostequal(z1poro.values.std(), 0.04, 0.003, "Std. dev")
+    z1poro = xtgeo.surface_from_file(os.path.join(TMPD, "z1--avg1b_average_por.gri"))
+    assert z1poro.values.mean() == pytest.approx(0.1598, abs=0.001)
+    assert z1poro.values.std() == pytest.approx(0.04, abs=0.003)
 
-    imgs = glob.glob(os.path.join(td, "*avg1b*.png"))
+    imgs = glob.glob(os.path.join(TMPD, "*avg1b*.png"))
     for img in imgs:
         shutil.copy2(img, "docs/test_images/.")
 
@@ -52,8 +52,8 @@ def test_average_map1c():
     os.chdir(str(Path(__file__).absolute().parent.parent))
     xx.main(["--config", "tests/yaml/avg1c.yml"])
 
-    z1poro = xtgeo.surface_from_file(os.path.join(td, "all--avg1c_average_por.gri"))
-    assert_almostequal(z1poro.values.mean(), 0.1678, 0.001, "Mean value")
+    z1poro = xtgeo.surface_from_file(os.path.join(TMPD, "all--avg1c_average_por.gri"))
+    assert z1poro.values.mean() == pytest.approx(0.1678, abs=0.001)
 
 
 def test_average_map1d():

--- a/tests/test_grid3d_average_map2.py
+++ b/tests/test_grid3d_average_map2.py
@@ -1,9 +1,10 @@
 import os
-import pytest
 from pathlib import Path
 
+import pytest
+
+import xtgeo
 from xtgeo.common import XTGeoDialog
-from xtgeo.surface import RegularSurface
 
 import xtgeoapp_grd3dmaps.avghc.grid3d_average_map as xxx
 
@@ -13,7 +14,7 @@ logger = xtg.basiclogger(__name__)
 if not xtg.testsetup():
     raise SystemExit
 
-td = xtg.tmpdir
+TMPD = xtg.tmpdir
 testpath = xtg.testpath
 
 skiplargetest = pytest.mark.skipif(xtg.bigtest is False, reason="Big tests skip")
@@ -26,18 +27,18 @@ skiplargetest = pytest.mark.skipif(xtg.bigtest is False, reason="Big tests skip"
 def test_average_map2a():
     """Test AVG with YAML config example 2a ECL based with filters"""
     os.chdir(str(Path(__file__).absolute().parent.parent))
-    dump = os.path.join(td, "avg2a.yml")
+    dump = os.path.join(TMPD, "avg2a.yml")
     xxx.main(["--config", "tests/yaml/avg2a.yml", "--dump", dump])
 
 
 def test_average_map2b():
     """Test AVG with YAML config example 2b, filters, zonation from prop"""
     os.chdir(str(Path(__file__).absolute().parent.parent))
-    dump = os.path.join(td, "avg2b.yml")
+    dump = os.path.join(TMPD, "avg2b.yml")
     xxx.main(["--config", "tests/yaml/avg2b.yml", "--dump", dump])
 
-    pfile = os.path.join(td, "myzone1--avg2b_average_pressure--20010101.gri")
-    pres = RegularSurface(pfile)
+    pfile = os.path.join(TMPD, "myzone1--avg2b_average_pressure--20010101.gri")
+    pres = xtgeo.surface_from_file(pfile)
 
     assert pres.values.mean() == pytest.approx(301.6917, abs=0.01)
 
@@ -45,10 +46,10 @@ def test_average_map2b():
 def test_average_map2c():
     """Test AVG with YAML config example 2c, filters, zonation from prop"""
     os.chdir(str(Path(__file__).absolute().parent.parent))
-    dump = os.path.join(td, "avg2c.yml")
+    dump = os.path.join(TMPD, "avg2c.yml")
     xxx.main(["--config", "tests/yaml/avg2c.yml", "--dump", dump])
 
-    pfile = os.path.join(td, "myzone1--avg2c_average_pressure--20010101.gri")
-    pres = RegularSurface(pfile)
+    pfile = os.path.join(TMPD, "myzone1--avg2c_average_pressure--20010101.gri")
+    pres = xtgeo.surface_from_file(pfile)
 
     assert pres.values.mean() == pytest.approx(301.689869, abs=0.01)

--- a/tests/test_grid3d_hc_thickness1.py
+++ b/tests/test_grid3d_hc_thickness1.py
@@ -5,12 +5,12 @@ import warnings
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 import xtgeo
 from xtgeo.common import XTGeoDialog
 
 import xtgeoapp_grd3dmaps.avghc.grid3d_hc_thickness as xx
-from .test_grid3d_hc_thickness2 import assert_almostequal
 
 xtg = XTGeoDialog()
 
@@ -20,7 +20,7 @@ logger = xtg.basiclogger(__name__)
 if not xtg.testsetup():
     raise SystemExit
 
-td = xtg.tmpdir
+TMPD = xtg.tmpdir
 testpath = xtg.testpath
 ojoin = os.path.join
 
@@ -32,30 +32,26 @@ ojoin = os.path.join
 def test_hc_thickness1a():
     """Test HC thickness with YAML config example 1a"""
     os.chdir(str(Path(__file__).absolute().parent.parent))
-    dmp = ojoin(td, "hc1a_dump.yml")
+    dmp = ojoin(TMPD, "hc1a_dump.yml")
     xx.main(["--config", "tests/yaml/hc_thickness1a.yml", "--dump", dmp])
 
     allz = xtgeo.surface_from_file(
-        ojoin(td, "all--oilthickness--20010101_19991201.gri")
+        ojoin(TMPD, "all--oilthickness--20010101_19991201.gri")
     )
     val = allz.values1d
 
     print(np.nanmean(val), np.nanstd(val))
 
     # -0.0574 in RMS volumetrics, but within range as different approach
-    assert_almostequal(np.nanmean(val), -0.03653, 0.001)
-    assert_almostequal(np.nanstd(val), 0.199886, 0.001)
-
-    # # legacy date format:
-    # xx.main(['--legacydateformat', '--config',
-    #          'tests/yaml/hc_thickness1a.yml'])
+    assert np.nanmean(val) == pytest.approx(-0.03653, 0.001)
+    assert np.nanstd(val) == pytest.approx(0.199886, 0.001)
 
 
 def test_hc_thickness1b():
     """HC thickness with YAML config example 1b; zonation in own YAML file"""
     os.chdir(str(Path(__file__).absolute().parent.parent))
     xx.main(["--config", "tests/yaml/hc_thickness1b.yml"])
-    imgs = glob.glob(ojoin(td, "*hc1b*.png"))
+    imgs = glob.glob(ojoin(TMPD, "*hc1b*.png"))
     print(imgs)
     for img in imgs:
         shutil.copy2(img, "docs/test_images/.")
@@ -73,9 +69,9 @@ def test_hc_thickness1d():
     warnings.simplefilter("error")
     xx.main(["--config", "tests/yaml/hc_thickness1d.yml"])
 
-    x1d = xtgeo.surface_from_file(ojoin(td, "all--hc1d_oilthickness--19991201.gri"))
+    x1d = xtgeo.surface_from_file(ojoin(TMPD, "all--hc1d_oilthickness--19991201.gri"))
 
-    assert_almostequal(x1d.values.mean(), 0.516, 0.001)
+    assert x1d.values.mean() == pytest.approx(0.516, abs=0.001)
 
 
 def test_hc_thickness1e():
@@ -83,9 +79,9 @@ def test_hc_thickness1e():
     os.chdir(str(Path(__file__).absolute().parent.parent))
     xx.main(["--config", "tests/yaml/hc_thickness1e.yml"])
 
-    x1e = xtgeo.surface_from_file(ojoin(td, "all--hc1e_oilthickness--19991201.gri"))
+    x1e = xtgeo.surface_from_file(ojoin(TMPD, "all--hc1e_oilthickness--19991201.gri"))
     logger.info(x1e.values.mean())
-    assert_almostequal(x1e.values.mean(), 0.516, 0.001)
+    assert x1e.values.mean() == pytest.approx(0.516, abs=0.001)
 
 
 def test_hc_thickness1f():
@@ -93,10 +89,10 @@ def test_hc_thickness1f():
     os.chdir(str(Path(__file__).absolute().parent.parent))
     xx.main(["--config", "tests/yaml/hc_thickness1f.yml"])
 
-    x1f = xtgeo.surface_from_file(ojoin(td, "all--hc1f_oilthickness--19991201.gri"))
+    x1f = xtgeo.surface_from_file(ojoin(TMPD, "all--hc1f_oilthickness--19991201.gri"))
     logger.info(x1f.values.mean())
     # other mean as the map is smaller; checked in RMS
-    assert_almostequal(x1f.values.mean(), 1.0999, 0.0001)
+    assert x1f.values.mean() == pytest.approx(1.0999, abs=0.0001)
 
 
 def test_hc_thickness1g():
@@ -105,13 +101,13 @@ def test_hc_thickness1g():
     os.chdir(str(Path(__file__).absolute().parent.parent))
     xx.main(["--config", "tests/yaml/hc_thickness1g.yml"])
 
-    x1g1 = xtgeo.surface_from_file(ojoin(td, "all--hc1g_oilthickness--19991201.gri"))
+    x1g1 = xtgeo.surface_from_file(ojoin(TMPD, "all--hc1g_oilthickness--19991201.gri"))
     logger.info(x1g1.values.mean())
-    assert_almostequal(x1g1.values.mean(), 1.0999, 0.0001)
+    assert x1g1.values.mean() == pytest.approx(1.0999, abs=0.0001)
 
-    x1g2 = xtgeo.surface_from_file(ojoin(td, "all--hc1g_gasthickness--19991201.gri"))
+    x1g2 = xtgeo.surface_from_file(ojoin(TMPD, "all--hc1g_gasthickness--19991201.gri"))
     logger.info(x1g1.values.mean())
-    assert_almostequal(x1g2.values.mean(), 0.000, 0.0001)
+    assert x1g2.values.mean() == pytest.approx(0.000, abs=0.0001)
 
 
 def test_hc_thickness1h():
@@ -120,15 +116,15 @@ def test_hc_thickness1h():
     xx.main(["--config", "tests/yaml/hc_thickness1h.yml"])
 
     allz = xtgeo.surface_from_file(
-        ojoin(td, "all--tuning_oilthickness--20010101_19991201.gri")
+        ojoin(TMPD, "all--tuning_oilthickness--20010101_19991201.gri")
     )
     val = allz.values1d
 
     print(np.nanmean(val), np.nanstd(val))
 
     # -0.0574 in RMS volumetrics, but within range as different approach
-    assert_almostequal(np.nanmean(val), -0.0336, 0.005)
-    assert_almostequal(np.nanstd(val), 0.1717, 0.005)
+    assert np.nanmean(val) == pytest.approx(-0.0336, abs=0.005)
+    assert np.nanstd(val) == pytest.approx(0.1717, abs=0.005)
 
 
 def test_hc_thickness1i():
@@ -137,11 +133,11 @@ def test_hc_thickness1i():
     xx.main(["--config", "tests/yaml/hc_thickness1i.yml"])
 
     allz = xtgeo.surface_from_file(
-        ojoin(td, "all--hc1i_oilthickness--20010101_19991201.gri")
+        ojoin(TMPD, "all--hc1i_oilthickness--20010101_19991201.gri")
     )
     val = allz.values
 
     print(val.mean())
 
     # -0.0574 in RMS volumetrics, but within range as different approach
-    assert_almostequal(val.mean(), -0.06, 0.01)
+    assert val.mean() == pytest.approx(-0.06, abs=0.01)

--- a/tests/test_grid3d_hc_thickness1.py
+++ b/tests/test_grid3d_hc_thickness1.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 import numpy as np
 
+import xtgeo
 from xtgeo.common import XTGeoDialog
-from xtgeo.surface import RegularSurface as RS
 
 import xtgeoapp_grd3dmaps.avghc.grid3d_hc_thickness as xx
 from .test_grid3d_hc_thickness2 import assert_almostequal
@@ -35,7 +35,9 @@ def test_hc_thickness1a():
     dmp = ojoin(td, "hc1a_dump.yml")
     xx.main(["--config", "tests/yaml/hc_thickness1a.yml", "--dump", dmp])
 
-    allz = RS(ojoin(td, "all--oilthickness--20010101_19991201.gri"))
+    allz = xtgeo.surface_from_file(
+        ojoin(td, "all--oilthickness--20010101_19991201.gri")
+    )
     val = allz.values1d
 
     print(np.nanmean(val), np.nanstd(val))
@@ -71,7 +73,7 @@ def test_hc_thickness1d():
     warnings.simplefilter("error")
     xx.main(["--config", "tests/yaml/hc_thickness1d.yml"])
 
-    x1d = RS(ojoin(td, "all--hc1d_oilthickness--19991201.gri"))
+    x1d = xtgeo.surface_from_file(ojoin(td, "all--hc1d_oilthickness--19991201.gri"))
 
     assert_almostequal(x1d.values.mean(), 0.516, 0.001)
 
@@ -81,7 +83,7 @@ def test_hc_thickness1e():
     os.chdir(str(Path(__file__).absolute().parent.parent))
     xx.main(["--config", "tests/yaml/hc_thickness1e.yml"])
 
-    x1e = RS(ojoin(td, "all--hc1e_oilthickness--19991201.gri"))
+    x1e = xtgeo.surface_from_file(ojoin(td, "all--hc1e_oilthickness--19991201.gri"))
     logger.info(x1e.values.mean())
     assert_almostequal(x1e.values.mean(), 0.516, 0.001)
 
@@ -91,7 +93,7 @@ def test_hc_thickness1f():
     os.chdir(str(Path(__file__).absolute().parent.parent))
     xx.main(["--config", "tests/yaml/hc_thickness1f.yml"])
 
-    x1f = RS(ojoin(td, "all--hc1f_oilthickness--19991201.gri"))
+    x1f = xtgeo.surface_from_file(ojoin(td, "all--hc1f_oilthickness--19991201.gri"))
     logger.info(x1f.values.mean())
     # other mean as the map is smaller; checked in RMS
     assert_almostequal(x1f.values.mean(), 1.0999, 0.0001)
@@ -103,11 +105,11 @@ def test_hc_thickness1g():
     os.chdir(str(Path(__file__).absolute().parent.parent))
     xx.main(["--config", "tests/yaml/hc_thickness1g.yml"])
 
-    x1g1 = RS(ojoin(td, "all--hc1g_oilthickness--19991201.gri"))
+    x1g1 = xtgeo.surface_from_file(ojoin(td, "all--hc1g_oilthickness--19991201.gri"))
     logger.info(x1g1.values.mean())
     assert_almostequal(x1g1.values.mean(), 1.0999, 0.0001)
 
-    x1g2 = RS(ojoin(td, "all--hc1g_gasthickness--19991201.gri"))
+    x1g2 = xtgeo.surface_from_file(ojoin(td, "all--hc1g_gasthickness--19991201.gri"))
     logger.info(x1g1.values.mean())
     assert_almostequal(x1g2.values.mean(), 0.000, 0.0001)
 
@@ -117,13 +119,9 @@ def test_hc_thickness1h():
     os.chdir(str(Path(__file__).absolute().parent.parent))
     xx.main(["--config", "tests/yaml/hc_thickness1h.yml"])
 
-    # now read in result and check avg value
-    # x = RegularSurface('TMP/gull_1985_10_01.gri')
-    # avg = float("{:4.3f}".format(float(x.values.mean())))
-    # logger.info("AVG is " + str(avg))
-    # assert avg == 3.649
-
-    allz = RS(ojoin(td, "all--tuning_oilthickness--20010101_19991201.gri"))
+    allz = xtgeo.surface_from_file(
+        ojoin(td, "all--tuning_oilthickness--20010101_19991201.gri")
+    )
     val = allz.values1d
 
     print(np.nanmean(val), np.nanstd(val))
@@ -138,13 +136,9 @@ def test_hc_thickness1i():
     os.chdir(str(Path(__file__).absolute().parent.parent))
     xx.main(["--config", "tests/yaml/hc_thickness1i.yml"])
 
-    # now read in result and check avg value
-    # x = RegularSurface('TMP/gull_1985_10_01.gri')
-    # avg = float("{:4.3f}".format(float(x.values.mean())))
-    # logger.info("AVG is " + str(avg))
-    # assert avg == 3.649
-
-    allz = RS(ojoin(td, "all--hc1i_oilthickness--20010101_19991201.gri"))
+    allz = xtgeo.surface_from_file(
+        ojoin(td, "all--hc1i_oilthickness--20010101_19991201.gri")
+    )
     val = allz.values
 
     print(val.mean())

--- a/tests/test_grid3d_hc_thickness2.py
+++ b/tests/test_grid3d_hc_thickness2.py
@@ -1,8 +1,8 @@
 import os
 import sys
+from pathlib import Path
 import pytest
 import numpy as np
-from pathlib import Path
 
 from xtgeo.common import XTGeoDialog
 import xtgeo
@@ -17,26 +17,8 @@ logger = xtg.basiclogger(__name__)
 if not xtg.testsetup():
     sys.exit(-9)
 
-td = xtg.tmpdir
+TMPD = xtg.tmpdir
 testpath = xtg.testpath
-
-
-# =============================================================================
-# Some useful functions
-# =============================================================================
-
-
-def assert_equal(this, that, txt=""):
-    assert this == that, txt
-
-
-def assert_almostequal(this, that, tol, txt=""):
-    assert this == pytest.approx(that, abs=tol), txt
-
-
-# =============================================================================
-# Do tests
-# =============================================================================
 
 
 def test_hc_thickness2a():
@@ -47,12 +29,12 @@ def test_hc_thickness2a():
     # read in result and check statistical values
 
     allz = xtgeo.surface_from_file(
-        os.path.join(td, "all--stoiip_oilthickness--19900101.gri")
+        os.path.join(TMPD, "all--stoiip_oilthickness--19900101.gri")
     )
 
     val = allz.values1d
     val[val <= 0] = np.nan
 
     # compared with data from RMS:
-    assert_almostequal(np.nanmean(val), 1.9521, 0.01)
-    assert_almostequal(np.nanstd(val), 1.2873, 0.01)
+    assert np.nanmean(val) == pytest.approx(1.9521, abs=0.01)
+    assert np.nanstd(val) == pytest.approx(1.2873, abs=0.01)

--- a/tests/test_grid3d_hc_thickness2.py
+++ b/tests/test_grid3d_hc_thickness2.py
@@ -5,7 +5,7 @@ import numpy as np
 from pathlib import Path
 
 from xtgeo.common import XTGeoDialog
-from xtgeo.surface import RegularSurface as RS
+import xtgeo
 
 import xtgeoapp_grd3dmaps.avghc.grid3d_hc_thickness as xx
 
@@ -46,7 +46,9 @@ def test_hc_thickness2a():
 
     # read in result and check statistical values
 
-    allz = RS(os.path.join(td, "all--stoiip_oilthickness--19900101.gri"))
+    allz = xtgeo.surface_from_file(
+        os.path.join(td, "all--stoiip_oilthickness--19900101.gri")
+    )
 
     val = allz.values1d
     val[val <= 0] = np.nan

--- a/tests/test_grid3d_hc_thickness3.py
+++ b/tests/test_grid3d_hc_thickness3.py
@@ -16,52 +16,33 @@ logger = xtg.basiclogger(__name__)
 if not xtg.testsetup():
     raise SystemExit
 
-td = xtg.tmpdir
-testpath = xtg.testpath
-
-
-# =============================================================================
-# Some useful functions
-# =============================================================================
-
-
-def assert_equal(this, that, txt=""):
-    assert this == that, txt
-
-
-def assert_almostequal(this, that, tol, txt=""):
-    assert this == pytest.approx(that, abs=tol), txt
-
-
-# =============================================================================
-# Do tests
-# =============================================================================
+TMPD = xtg.tmpdir
 
 
 def test_hc_thickness3a():
     """HC thickness with external configfiles, HC 3a"""
     os.chdir(str(Path(__file__).absolute().parent.parent))
-    dump = os.path.join(td, "hc3a.yml")
+    dump = os.path.join(TMPD, "hc3a.yml")
     xxx.main(["--config", "tests/yaml/hc_thickness3a.yml", "--dump", dump])
 
 
 def test_hc_thickness3b():
     """HC thickness with external configfiles, HC 3b"""
     os.chdir(str(Path(__file__).absolute().parent.parent))
-    dump = os.path.join(td, "hc3b.yml")
+    dump = os.path.join(TMPD, "hc3b.yml")
     xxx.main(["--config", "tests/yaml/hc_thickness3b.yml", "--dump", dump])
 
 
 def test_hc_thickness3c():
     """HC thickness with external configfiles, HC 3c"""
     os.chdir(str(Path(__file__).absolute().parent.parent))
-    dump = os.path.join(td, "hc3c.yml")
+    dump = os.path.join(TMPD, "hc3c.yml")
     xxx.main(["--config", "tests/yaml/hc_thickness3c.yml", "--dump", dump])
 
-    result = os.path.join(td, "myfip1--hc3c_oilthickness--19991201.gri")
+    result = os.path.join(TMPD, "myfip1--hc3c_oilthickness--19991201.gri")
     res = xtgeo.surface_from_file(result)
     assert res.values.max() == pytest.approx(13.5681, abs=0.001)  # qc'ed RMS
 
-    result = os.path.join(td, "myfip2--hc3c_oilthickness--19991201.gri")
+    result = os.path.join(TMPD, "myfip2--hc3c_oilthickness--19991201.gri")
     res = xtgeo.surface_from_file(result)
     assert res.values.max() == pytest.approx(0.0, abs=0.001)  # qc'ed RMS

--- a/tests/test_grid3d_hc_thickness3.py
+++ b/tests/test_grid3d_hc_thickness3.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 import pytest
 
+import xtgeo
 from xtgeo.common import XTGeoDialog
-from xtgeo.surface import RegularSurface
 
 import xtgeoapp_grd3dmaps.avghc.grid3d_hc_thickness as xxx
 
@@ -59,9 +59,9 @@ def test_hc_thickness3c():
     xxx.main(["--config", "tests/yaml/hc_thickness3c.yml", "--dump", dump])
 
     result = os.path.join(td, "myfip1--hc3c_oilthickness--19991201.gri")
-    res = RegularSurface(result)
+    res = xtgeo.surface_from_file(result)
     assert res.values.max() == pytest.approx(13.5681, abs=0.001)  # qc'ed RMS
 
     result = os.path.join(td, "myfip2--hc3c_oilthickness--19991201.gri")
-    res = RegularSurface(result)
+    res = xtgeo.surface_from_file(result)
     assert res.values.max() == pytest.approx(0.0, abs=0.001)  # qc'ed RMS

--- a/tests/test_grid3d_hc_thickness4.py
+++ b/tests/test_grid3d_hc_thickness4.py
@@ -1,10 +1,10 @@
 import os
 from pathlib import Path
-
 import pytest
 
+import xtgeo
 from xtgeo.common import XTGeoDialog
-from xtgeo.surface import RegularSurface
+
 
 import xtgeoapp_grd3dmaps.avghc.grid3d_hc_thickness as xxx
 
@@ -16,36 +16,18 @@ logger = xtg.basiclogger(__name__)
 if not xtg.testsetup():
     raise SystemExit
 
-td = xtg.tmpdir
+TMPD = xtg.tmpdir
 testpath = xtg.testpath
-
-
-# =============================================================================
-# Some useful functions
-# =============================================================================
-
-
-def assert_equal(this, that, txt=""):
-    assert this == that, txt
-
-
-def assert_almostequal(this, that, tol, txt=""):
-    assert this == pytest.approx(that, abs=tol), txt
-
-
-# =============================================================================
-# Do tests
-# =============================================================================
 
 
 def test_hc_thickness4a():
     """HC thickness with external configfiles, HC 4a"""
     os.chdir(str(Path(__file__).absolute().parent.parent))
-    dump = os.path.join(td, "hc4a.yml")
+    dump = os.path.join(TMPD, "hc4a.yml")
     xxx.main(["--config", "tests/yaml/hc_thickness4a.yml", "--dump", dump])
 
     # check result
-    mapfile = os.path.join(td, "all--hc4a_rockthickness.gri")
-    mymap = RegularSurface(mapfile)
+    mapfile = os.path.join(TMPD, "all--hc4a_rockthickness.gri")
+    mymap = xtgeo.surface_from_file(mapfile)
 
-    assert_almostequal(mymap.values.mean(), 0.76590, 0.001)
+    assert mymap.values.mean() == pytest.approx(0.76590, abs=0.001)

--- a/tests/test_hook_implementations.py
+++ b/tests/test_hook_implementations.py
@@ -10,8 +10,8 @@ except ImportError:
         "Not testing ERT hooks when ERT is not installed", allow_module_level=True
     )
 
-import xtgeoapp_grd3dmaps.hook_implementations.jobs as jobs
 from ert_shared.plugins.plugin_manager import ErtPluginManager
+import xtgeoapp_grd3dmaps.hook_implementations.jobs as jobs
 
 EXPECTED_JOBS = {
     "GRID3D_AVERAGE_MAP": "xtgeoapp_grd3dmaps/config_jobs/GRID3D_AVERAGE_MAP",


### PR DESCRIPTION
For `xtgeo`, it is planned to deprecate plotting/matplotlib and rather keep that functionality as a separate package: `xtgeoviz`. This PR is preparing for that.

Also initializing surfaces from files via `RegularSurface("some_file")` is deprecated in `xtgeo` from coming version 2.15. Instead objects are initialized by `xtgeo.surface_from_file(..)` 

In addition, several code enhancements (identified by linters) is corrected. Some unneccessary logging prints are disables,  but there shall be no changes in functionality.
