### PR TITLE
Migrate to new ert import structure

### DIFF
--- a/.github/workflows/test_vs_ert.yml
+++ b/.github/workflows/test_vs_ert.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Run test vs ERT
         # the promise install is needed due to bug in ERT installer; remove when fixed
         run: >
-          python -m pip install ert &&
+          python -m pip install ert>=2.38.0b5 &&
           python -m pip install promise &&
           python -m pytest tests/test_vs_ert --disable-warnings -x

--- a/src/xtgeoapp_grd3dmaps/hook_implementations/jobs.py
+++ b/src/xtgeoapp_grd3dmaps/hook_implementations/jobs.py
@@ -2,8 +2,12 @@ import importlib
 import os
 from pkg_resources import resource_filename
 
-from ert_shared.plugins.plugin_manager import hook_implementation
-from ert_shared.plugins.plugin_response import plugin_response
+try:
+    from ert_shared.plugins.plugin_manager import hook_implementation
+    from ert_shared.plugins.plugin_response import plugin_response
+except ModuleNotFoundError:
+    from ert.shared.plugins.plugin_manager import hook_implementation
+    from ert.shared.plugins.plugin_response import plugin_response
 
 PLUGIN_NAME = "xtgeoapp_grd3dmaps"
 

--- a/tests/test_vs_ert/test_hook_implementations.py
+++ b/tests/test_vs_ert/test_hook_implementations.py
@@ -8,12 +8,18 @@ import pytest
 try:
     import ert_shared  # noqa
 except ImportError:
-    pytest.skip(
-        "Not testing ERT hooks when ERT is not installed", allow_module_level=True
-    )
+    try:
+        import ert # noqa
+    except ImportError:
+        pytest.skip(
+            "Not testing ERT hooks when ERT is not installed", allow_module_level=True
+        )
 
 import xtgeoapp_grd3dmaps.hook_implementations.jobs as jobs
-from ert_shared.plugins.plugin_manager import ErtPluginManager
+try:
+    from ert_shared.plugins.plugin_manager import ErtPluginManager
+except ModuleNotFoundError:
+    from ert.shared.plugins.plugin_manager import ErtPluginManager
 
 EXPECTED_JOBS = {
     "GRID3D_AVERAGE_MAP": "xtgeoapp_grd3dmaps/config_jobs/GRID3D_AVERAGE_MAP",


### PR DESCRIPTION
Migrate to new ERT import structure. Testing if the ERT tests should be skipped is not really elegant, but it can be returned to the way it was prior to this PR when support for Python 3.6 is dropped (this also goes for the try, except blocks when importing plugin related things). 
