### PR TITLE
Reverse import order

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 pyyaml
 xtgeo
-fmu-dataio
+fmu-dataio>=1.0.0
 xtgeoviz

--- a/src/xtgeoapp_grd3dmaps/avghc/_export_via_fmudataio.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_export_via_fmudataio.py
@@ -60,7 +60,7 @@ def export_avg_map_dataio(surf, nametuple, config):
         workflow="xtgeoapp-grd3dmaps script average maps",
     )
     fname = edata.export(surf, unit=unit)
-    xtg.say(f"Outout as fmu-dataio: {fname}")
+    xtg.say(f"Output as fmu-dataio: {fname}")
     return fname
 
 

--- a/src/xtgeoapp_grd3dmaps/hook_implementations/jobs.py
+++ b/src/xtgeoapp_grd3dmaps/hook_implementations/jobs.py
@@ -3,11 +3,11 @@ import os
 from pkg_resources import resource_filename
 
 try:
-    from ert_shared.plugins.plugin_manager import hook_implementation
-    from ert_shared.plugins.plugin_response import plugin_response
-except ModuleNotFoundError:
     from ert.shared.plugins.plugin_manager import hook_implementation
     from ert.shared.plugins.plugin_response import plugin_response
+except ModuleNotFoundError:
+    from ert_shared.plugins.plugin_manager import hook_implementation
+    from ert_shared.plugins.plugin_response import plugin_response
 
 PLUGIN_NAME = "xtgeoapp_grd3dmaps"
 

--- a/tests/test_scripts/test_grid3d_average_map_dataio1a.py
+++ b/tests/test_scripts/test_grid3d_average_map_dataio1a.py
@@ -105,7 +105,7 @@ def test_average_map_dataio1a_add2docs(datatree):
         print(json.dumps(metadata, indent=4))
 
     assert metadata["data"]["spec"]["ncol"] == 200
-    assert metadata["data"]["property"]["attribute"] == "saturation"
+    assert metadata["data"]["content"]["property"]["attribute"] == "saturation"
 
     # for auto documentation
     shutil.copy2(cfg, SOURCEPATH / "docs" / "test_to_docs")

--- a/tests/test_scripts/test_grid3d_hc_thickness_dataio1a.py
+++ b/tests/test_scripts/test_grid3d_hc_thickness_dataio1a.py
@@ -74,7 +74,7 @@ def test_hc_thickness_1a_add2docs(datatree):
         print(json.dumps(metadata, indent=4))
 
     assert metadata["data"]["spec"]["ncol"] == 146
-    assert metadata["data"]["property"]["attribute"] == "oilthickness"
+    assert metadata["data"]["content"]["property"]["attribute"] == "oilthickness"
 
     # for auto documentation
     shutil.copy2(cfg, SOURCEPATH / "docs" / "test_to_docs")

--- a/tests/test_scripts/test_grid3d_hc_thickness_dataio1b.py
+++ b/tests/test_scripts/test_grid3d_hc_thickness_dataio1b.py
@@ -74,7 +74,7 @@ def test_hc_thickness_1b_add2docs(datatree):
         print(json.dumps(metadata, indent=4))
 
     assert metadata["data"]["spec"]["ncol"] == 161
-    assert metadata["data"]["property"]["attribute"] == "oilthickness"
+    assert metadata["data"]["content"]["property"]["attribute"] == "oilthickness"
 
     # for auto documentation
     shutil.copy2(cfg, SOURCEPATH / "docs" / "test_to_docs")

--- a/tests/test_scripts/test_grid3d_hc_thickness_dataio1c.py
+++ b/tests/test_scripts/test_grid3d_hc_thickness_dataio1c.py
@@ -73,7 +73,7 @@ def test_hc_thickness_1c_add2docs(datatree):
         print(json.dumps(metadata, indent=4))
 
     assert metadata["data"]["spec"]["ncol"] == 292
-    assert metadata["data"]["time"][0]["value"] == "1990-01-01T00:00:00"
+    assert metadata["data"]["time"]["t0"]["value"] == "1990-01-01T00:00:00"
 
     # for auto documentation
     shutil.copy2(cfg, SOURCEPATH / "docs" / "test_to_docs")

--- a/tests/test_vs_ert/test_hook_implementations.py
+++ b/tests/test_vs_ert/test_hook_implementations.py
@@ -6,20 +6,21 @@ from pathlib import Path
 import pytest
 
 try:
-    import ert_shared  # noqa
+    import ert  # noqa
 except ImportError:
     try:
-        import ert # noqa
+        import ert_shared  # noqa
     except ImportError:
         pytest.skip(
             "Not testing ERT hooks when ERT is not installed", allow_module_level=True
         )
 
 import xtgeoapp_grd3dmaps.hook_implementations.jobs as jobs
+
 try:
-    from ert_shared.plugins.plugin_manager import ErtPluginManager
-except ModuleNotFoundError:
     from ert.shared.plugins.plugin_manager import ErtPluginManager
+except ModuleNotFoundError:
+    from ert_shared.plugins.plugin_manager import ErtPluginManager
 
 EXPECTED_JOBS = {
     "GRID3D_AVERAGE_MAP": "xtgeoapp_grd3dmaps/config_jobs/GRID3D_AVERAGE_MAP",


### PR DESCRIPTION
Try importing the new package names before importing the deprecated, avoiding a potential deprecation warning in case a compatibility package is installed.