### PR TITLE
Fix GRID3D_MIGRATION_TIME example to match config

### DIFF
--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -10,7 +10,7 @@ jobs:
   testing:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         os: [ubuntu-latest]
         include:
           - os: macos-latest

--- a/.github/workflows/test_vs_ert.yml
+++ b/.github/workflows/test_vs_ert.yml
@@ -10,7 +10,7 @@ jobs:
   test_vs_ert:
     strategy:
       matrix:
-        python-version: [3.6, 3.8]
+        python-version: [3.8]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/xtgeoapp_grd3dmaps/aggregate/grid3d_migration_time.py
+++ b/src/xtgeoapp_grd3dmaps/aggregate/grid3d_migration_time.py
@@ -22,7 +22,7 @@ CATEGORY = "modelling.reservoir"
 EXAMPLES = """
 .. code-block:: console
 
-  FORWARD_MODEL GRID3D_MIGRATION_TIME(<CONFIG_AGGMAP>=conf.yml, <ECLROOT>=<ECLBASE>)
+  FORWARD_MODEL GRID3D_MIGRATION_TIME(<CONFIG_MIGTIME>=conf.yml, <ECLROOT>=<ECLBASE>)
 """
 
 


### PR DESCRIPTION
Fixup so the example matches the config: https://github.com/equinor/xtgeoapp-grd3dmaps/blob/master/src/xtgeoapp_grd3dmaps/config_jobs/GRID3D_MIGRATION_TIME#L2

Also remove testing against Python 3.6, as this is no longer available :slightly_smiling_face: 