### PR TITLE
Support Python 3.10 

### DIFF
--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -10,17 +10,13 @@ jobs:
   testing:
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
-        os: [ubuntu-latest]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        os: [ubuntu-20.04]
         include:
           - os: macos-latest
             python-version: 3.8
           - os: windows-latest
             python-version: 3.8
-          - os: ubuntu-latest
-            python-version: 3.7
-          - os: ubuntu-latest
-            python-version: 3.9
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -10,7 +10,7 @@ jobs:
   testing:
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
         os: [ubuntu-latest]
         include:
           - os: macos-latest

--- a/.github/workflows/test_vs_ert.yml
+++ b/.github/workflows/test_vs_ert.yml
@@ -10,7 +10,7 @@ jobs:
   test_vs_ert:
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [ '3.8', '3.9', '3.10' ]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Skipping 3.11 for the ERT integration tests as
ERT does not support 3.11