### PR TITLE
Fix grid3d average map

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,9 @@ def src(anypath):
 setup(
     name="xtgeoapp_grd3dmaps",
     use_scm_version={
-        "root": src(""),
-        "write_to": src("src/xtgeoapp_grd3dmaps/_theversion.py"),
+        # "root": src(""),
+        # "write_to": src("src/xtgeoapp_grd3dmaps/_theversion.py"),
+        "write_to": "src/xtgeoapp_grd3dmaps/_theversion.py",
     },
     description="Make HC thickness, avg maps, etc directly from 3D props",
     long_description=readme + "\n\n" + history,
@@ -86,5 +87,5 @@ setup(
     install_requires=REQUIREMENTS,
     tests_require=REQUIREMENTS_TESTS,
     setup_requires=REQUIREMENTS_SETUP,
-    extras_requires=REQUIREMENTS_EXTRAS,
+    extras_require=REQUIREMENTS_EXTRAS,
 )

--- a/src/xtgeoapp_grd3dmaps/avghc/_get_grid_props.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_get_grid_props.py
@@ -157,7 +157,8 @@ def import_data(appname, gfile, initlist, restartlist, dates):
 
     initdict = defaultdict(list)
     for ipar, ifile in initlist.items():
-
+        if ipar == "fmu_global_config":
+            continue
         if isinstance(ifile, dict):
             lookfor, usefile = list(ifile.keys()), list(ifile.values())
             initdict[usefile[0]].append([ipar, lookfor[0]])

--- a/src/xtgeoapp_grd3dmaps/avghc/_get_grid_props.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/_get_grid_props.py
@@ -125,7 +125,7 @@ def files_to_import(config, appname):
     return gfile, initlist, restartlist, dates
 
 
-def import_data(_, appname, gfile, initlist, restartlist, dates):
+def import_data(appname, gfile, initlist, restartlist, dates):
     """Get the grid and the props data.
     Well get the grid and the propsdata for data to be plotted,
     zonation (if required), filters (if required)
@@ -137,9 +137,7 @@ def import_data(_, appname, gfile, initlist, restartlist, dates):
         appname(str): Name of application
 
     """
-
     logger.info("Import data for %s", appname)
-
     # get the grid data + some geometrics
     grd = xtgeo.grid_from_file(gfile)
 

--- a/src/xtgeoapp_grd3dmaps/avghc/grid3d_average_map.py
+++ b/src/xtgeoapp_grd3dmaps/avghc/grid3d_average_map.py
@@ -97,7 +97,7 @@ def import_pdata(config, gfile, initlist, restartlist, dates):
     """Import the data, and represent datas as numpies"""
 
     grd, initobjects, restobjects, dates = _get_grid_props.import_data(
-        config, APPNAME, gfile, initlist, restartlist, dates
+        APPNAME, gfile, initlist, restartlist, dates
     )
     specd, averaged = _get_grid_props.get_numpies_avgprops(
         config, grd, initobjects, restobjects


### PR DESCRIPTION
When running with config example file example from jriv the example fails when running command: 
grid3d_average_map --config /project/fmu/tutorial/drogon/resmod/ff/users/jriv/dev/dev_20230426/ert/input/config/ecl_avg_map.yml --eclroot eclipse/model/DROGON-0

This PR fixes so that this command runs and produces results as expected.