### PR TITLE
Fix `GRID3d_AGGREGATE_MAP` parameter documentation

### DIFF
--- a/src/xtgeoapp_grd3dmaps/aggregate/grid3d_aggregate_map.py
+++ b/src/xtgeoapp_grd3dmaps/aggregate/grid3d_aggregate_map.py
@@ -32,7 +32,7 @@ CATEGORY = "modelling.reservoir"
 EXAMPLES = """
 .. code-block:: console
 
-  FORWARD_MODEL GRID3D_AGGREGATE_MAP(<CONFIG_AGGMAP>=conf.yml, <ECLROOT>=<ECLBASE>)
+  FORWARD_MODEL GRID3D_AGGREGATE_MAP(<CONFIG_AGGREGATE>=conf.yml, <ECLROOT>=<ECLBASE>)
 """
 
 


### PR DESCRIPTION
The example given for documentation used the `CONFIG_AGGMAP` argument while the forward describes that it takes the `CONFIG_AGGREGATE` argument.

Resolves #90